### PR TITLE
Update mds-worldpay-woocommerce-admin.js

### DIFF
--- a/admin/assets/js/mds-worldpay-woocommerce-admin.js
+++ b/admin/assets/js/mds-worldpay-woocommerce-admin.js
@@ -1,5 +1,6 @@
 (function ($) {
     'use strict';
+    if (!$('#woocommerce_business_worldpay_api_md5_fields').length ) { return; }
 
     var $select2 = $('#woocommerce_business_worldpay_api_md5_fields').select2();
 


### PR DESCRIPTION
Checks if Worldpay element exists before trying to work with it as causing error: mds-worldpay-woocommerce-admin.js?ver=1.4.0:12 Uncaught TypeError: Cannot read property 'forEach' of undefined.